### PR TITLE
Add embedder injection, PostgreSQL resilience, chunk filtering and dimension inference

### DIFF
--- a/API.md
+++ b/API.md
@@ -221,6 +221,27 @@ kb = Ragi("./docs", store="s3://bucket/indices")  # S3-backed
 ```python
 kb = Ragi("./docs", store="postgres://user:pass@localhost/db")
 ```
+
+Direct store configuration with retry options:
+```python
+from piragi.stores import PostgresStore
+
+store = PostgresStore(
+    connection_string="postgres://user:pass@localhost/db",
+    table_name="chunks",           # Table name (default: "chunks")
+    vector_dimension=768,          # Vector dimensions (default: 768, or auto-inferred)
+    max_retries=3,                 # Retry attempts for transient failures (default: 3)
+    retry_delay=0.5,               # Base delay between retries in seconds (default: 0.5)
+    embedder=embedder,             # Optional: auto-infer dimensions from embedder
+)
+kb = Ragi("./docs", store=store)
+```
+
+The PostgresStore includes automatic connection resilience:
+- Retries on "transaction aborted" errors
+- Reconnects on connection failures
+- Exponential backoff between retries
+
 Requires: `pip install piragi[postgres]`
 
 ### Pinecone

--- a/API.md
+++ b/API.md
@@ -16,6 +16,7 @@ Ragi(
     persist_dir: str = ".piragi",
     config: Optional[Dict[str, Any]] = None,
     store: Union[str, Dict, VectorStoreProtocol, None] = None,
+    embedder: Optional[EmbeddingGenerator] = None,
 )
 ```
 
@@ -24,6 +25,7 @@ Ragi(
 - `persist_dir` - Directory to persist vector database
 - `config` - Configuration dict (see Configuration section)
 - `store` - Vector store backend (URI string, dict, or VectorStoreProtocol instance)
+- `embedder` - Custom EmbeddingGenerator instance. If provided, this embedder is used instead of creating one from config. Useful for sharing a single embedder across multiple Ragi instances to reduce memory usage.
 
 **Examples:**
 ```python
@@ -43,6 +45,12 @@ kb = Ragi("./docs", config={
 
 # Custom store
 kb = Ragi("./docs", store="postgres://user:pass@localhost/db")
+
+# Shared embedder (reduces memory when using multiple instances)
+from piragi import EmbeddingGenerator
+embedder = EmbeddingGenerator(model="all-mpnet-base-v2")
+kb1 = Ragi("./docs1", embedder=embedder)
+kb2 = Ragi("./docs2", embedder=embedder)  # Shares same embedder
 ```
 
 ### Methods
@@ -92,6 +100,64 @@ Number of chunks in the knowledge base.
 
 #### `clear() -> None`
 Clear all data.
+
+## AsyncRagi
+
+Async wrapper for use with async web frameworks (FastAPI, Starlette, aiohttp).
+
+```python
+from piragi import AsyncRagi
+```
+
+### Constructor
+
+```python
+AsyncRagi(
+    sources: Union[str, List[str], None] = None,
+    persist_dir: str = ".piragi",
+    config: Optional[Dict[str, Any]] = None,
+    store: Union[str, Dict, VectorStoreProtocol, None] = None,
+    graph: bool = False,
+    embedder: Optional[EmbeddingGenerator] = None,
+)
+```
+
+**Parameters:** Same as Ragi (see above).
+
+**Examples:**
+```python
+# Basic async usage
+kb = AsyncRagi("./docs")
+answer = await kb.ask("How do I deploy?")
+
+# With progress tracking
+async for progress in kb.add("./large-docs", progress=True):
+    print(progress)
+
+# Shared embedder across async instances
+from piragi import EmbeddingGenerator
+embedder = EmbeddingGenerator(model="all-mpnet-base-v2")
+kb1 = AsyncRagi("./docs1", embedder=embedder)
+kb2 = AsyncRagi("./docs2", embedder=embedder)
+
+# With FastAPI
+@app.post("/search")
+async def search(query: str):
+    return await kb.ask(query)
+```
+
+### Methods
+
+All methods are async versions of Ragi methods:
+- `await kb.add(sources)` - Add documents
+- `await kb.ask(query)` - Ask a question
+- `await kb.retrieve(query)` - Retrieve chunks
+- `await kb.refresh(sources)` - Refresh sources
+- `await kb.count()` - Get chunk count
+- `await kb.clear()` - Clear data
+- `kb.filter(**kwargs)` - Filter (sync, returns self for chaining)
+
+---
 
 ## Data Types
 

--- a/API.md
+++ b/API.md
@@ -222,25 +222,29 @@ kb = Ragi("./docs", store="s3://bucket/indices")  # S3-backed
 kb = Ragi("./docs", store="postgres://user:pass@localhost/db")
 ```
 
-Direct store configuration with retry options:
+Direct store configuration with all options:
 ```python
+from piragi import EmbeddingGenerator
 from piragi.stores import PostgresStore
 
+# Create embedder first
+embedder = EmbeddingGenerator(model="all-MiniLM-L6-v2")
+
+# Auto-infer dimensions from embedder (384 for MiniLM)
 store = PostgresStore(
     connection_string="postgres://user:pass@localhost/db",
     table_name="chunks",           # Table name (default: "chunks")
-    vector_dimension=768,          # Vector dimensions (default: 768, or auto-inferred)
     max_retries=3,                 # Retry attempts for transient failures (default: 3)
     retry_delay=0.5,               # Base delay between retries in seconds (default: 0.5)
     embedder=embedder,             # Optional: auto-infer dimensions from embedder
 )
-kb = Ragi("./docs", store=store)
+kb = Ragi("./docs", store=store, embedder=embedder)
 ```
 
-The PostgresStore includes automatic connection resilience:
-- Retries on "transaction aborted" errors
-- Reconnects on connection failures
-- Exponential backoff between retries
+The PostgresStore includes:
+- **Auto-dimension inference**: Pass an embedder to automatically detect vector dimensions
+- **Connection resilience**: Automatic retries on transient failures with exponential backoff
+- Handles "transaction aborted" errors and connection failures
 
 Requires: `pip install piragi[postgres]`
 

--- a/src/piragi/async_ragi.py
+++ b/src/piragi/async_ragi.py
@@ -5,6 +5,7 @@ import queue
 from typing import Any, AsyncIterator, Dict, List, Optional, Union
 
 from .core import Ragi
+from .embeddings import EmbeddingGenerator
 from .stores import VectorStoreProtocol
 from .types import Answer
 
@@ -26,6 +27,12 @@ class AsyncRagi:
         >>> async for progress in kb.add("./large-docs", progress=True):
         >>>     print(progress)
         >>>
+        >>> # With shared embedder
+        >>> from piragi import EmbeddingGenerator
+        >>> embedder = EmbeddingGenerator(model="custom-model")
+        >>> kb1 = AsyncRagi("./docs1", embedder=embedder)
+        >>> kb2 = AsyncRagi("./docs2", embedder=embedder)
+        >>>
         >>> # With FastAPI
         >>> @app.post("/ingest")
         >>> async def ingest(files: list[str]):
@@ -40,6 +47,7 @@ class AsyncRagi:
         config: Optional[Dict[str, Any]] = None,
         store: Union[str, Dict[str, Any], VectorStoreProtocol, None] = None,
         graph: bool = False,
+        embedder: Optional[EmbeddingGenerator] = None,
     ) -> None:
         """
         Initialize AsyncRagi with optional document sources.
@@ -50,6 +58,9 @@ class AsyncRagi:
             config: Configuration dict (see Ragi for options)
             store: Vector store backend
             graph: Enable knowledge graph
+            embedder: Optional custom EmbeddingGenerator instance. If provided, this
+                embedder will be used instead of creating a new one from config.
+                Useful for sharing a single embedder across multiple AsyncRagi instances.
         """
         self._sync = Ragi(
             sources=sources,
@@ -57,6 +68,7 @@ class AsyncRagi:
             config=config,
             store=store,
             graph=graph,
+            embedder=embedder,
         )
 
     def add(

--- a/src/piragi/chunking.py
+++ b/src/piragi/chunking.py
@@ -17,6 +17,7 @@ class Chunker:
         chunk_size: int = 512,
         chunk_overlap: int = 50,
         tokenizer_name: str = "nvidia/llama-embed-nemotron-8b",
+        min_chunk_length: int = 0,
     ) -> None:
         """
         Initialize the chunker.
@@ -25,9 +26,14 @@ class Chunker:
             chunk_size: Target chunk size in tokens
             chunk_overlap: Number of tokens to overlap between chunks
             tokenizer_name: Tokenizer to use (default: nvidia/llama-embed-nemotron-8b)
+            min_chunk_length: Minimum chunk length in characters. Chunks shorter than
+                this (after stripping whitespace) will be filtered out. Useful for
+                removing garbage chunks like navigation elements, short headers, etc.
+                Default is 0 (no filtering).
         """
         self.chunk_size = chunk_size
         self.chunk_overlap = chunk_overlap
+        self.min_chunk_length = min_chunk_length
         self.tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
         self._segmenter = pysbd.Segmenter(language="en", clean=False)
 
@@ -39,7 +45,7 @@ class Chunker:
             document: Document to chunk
 
         Returns:
-            List of chunks
+            List of chunks (filtered by min_chunk_length if set)
         """
         # Split by markdown headers first to respect document structure
         sections = self._split_by_headers(document.content)
@@ -55,6 +61,16 @@ class Chunker:
         # Add document metadata to all chunks
         for chunk in chunks:
             chunk.metadata.update(document.metadata)
+
+        # Filter out short chunks if min_chunk_length is set
+        if self.min_chunk_length > 0:
+            chunks = [
+                chunk for chunk in chunks
+                if len(chunk.text.strip()) >= self.min_chunk_length
+            ]
+            # Re-index chunks after filtering
+            for i, chunk in enumerate(chunks):
+                chunk.chunk_index = i
 
         return chunks
 

--- a/src/piragi/core.py
+++ b/src/piragi/core.py
@@ -8,7 +8,7 @@ from .embeddings import EmbeddingGenerator
 from .loader import DocumentLoader
 from .retrieval import Retriever
 from .stores import VectorStoreProtocol, create_store
-from .types import Answer, Chunk, Document, ChunkHook, DocumentHook
+from .types import Answer, Document, ChunkHook, DocumentHook
 from .async_updater import AsyncUpdater
 from .change_detection import ChangeDetector
 
@@ -31,6 +31,12 @@ class Ragi:
         ...     "embedding": {"device": "cuda"}
         ... })
         >>>
+        >>> # Custom embedder (shared across instances)
+        >>> from piragi import EmbeddingGenerator
+        >>> embedder = EmbeddingGenerator(model="custom-model")
+        >>> kb1 = Ragi("./docs1", embedder=embedder)
+        >>> kb2 = Ragi("./docs2", embedder=embedder)
+        >>>
         >>> # Ask questions
         >>> answer = kb.ask("How do I install this?")
         >>> print(answer.text)
@@ -47,6 +53,7 @@ class Ragi:
         store: Union[str, Dict[str, Any], VectorStoreProtocol, None] = None,
         hooks: Optional[Dict[str, Any]] = None,
         graph: bool = False,
+        embedder: Optional[EmbeddingGenerator] = None,
     ) -> None:
         """
         Initialize Ragi with optional document sources.
@@ -70,6 +77,9 @@ class Ragi:
                     - overlap: Overlap in tokens (default: 50)
                     - strategy: Chunking strategy (default: "fixed")
                         Options: "fixed", "semantic", "contextual", "hierarchical"
+                    - min_chunk_length: Minimum chunk length in characters (default: 0)
+                        Chunks shorter than this are filtered out. Useful for removing
+                        garbage chunks like navigation elements, short headers, etc.
                 - retrieval: Retrieval configuration
                     - use_hyde: Enable HyDE (default: False)
                     - use_hybrid_search: Enable BM25 + vector hybrid (default: False)
@@ -98,6 +108,10 @@ class Ragi:
                     Signature: (chunks: List[Chunk]) -> List[Chunk]
             graph: Enable knowledge graph for entity/relationship extraction (default: False)
                 Requires: pip install piragi[graph]
+            embedder: Optional custom EmbeddingGenerator instance. If provided, this
+                embedder will be used instead of creating a new one from config.
+                Useful for sharing a single embedder across multiple Ragi instances
+                to reduce memory usage and loading time.
 
         Examples:
             >>> # Use defaults
@@ -169,20 +183,27 @@ class Ragi:
             self.chunker = Chunker(
                 chunk_size=chunk_cfg.get("size", 512),
                 chunk_overlap=chunk_cfg.get("overlap", 50),
+                min_chunk_length=chunk_cfg.get("min_chunk_length", 0),
             )
 
         self._use_hierarchical = chunk_strategy == "hierarchical"
 
-        # Embeddings
+        # Embeddings - use provided embedder or create new one
         embed_cfg = cfg.get("embedding", {})
         embed_model = embed_cfg.get("model", "all-mpnet-base-v2")
-        self.embedder = EmbeddingGenerator(
-            model=embed_model,
-            device=embed_cfg.get("device"),
-            base_url=embed_cfg.get("base_url"),
-            api_key=embed_cfg.get("api_key"),
-            batch_size=embed_cfg.get("batch_size", 32),
-        )
+        if embedder is not None:
+            self.embedder = embedder
+            # Try to get model name from the provided embedder for store configuration
+            if hasattr(embedder, "model_name"):
+                embed_model = embedder.model_name
+        else:
+            self.embedder = EmbeddingGenerator(
+                model=embed_model,
+                device=embed_cfg.get("device"),
+                base_url=embed_cfg.get("base_url"),
+                api_key=embed_cfg.get("api_key"),
+                batch_size=embed_cfg.get("batch_size", 32),
+            )
 
         # Vector store - supports multiple backends
         self.store = create_store(

--- a/src/piragi/embeddings.py
+++ b/src/piragi/embeddings.py
@@ -126,6 +126,24 @@ class EmbeddingGenerator:
         except Exception as e:
             raise RuntimeError(f"Failed to generate embeddings: {e}")
 
+    def get_dimensions(self) -> int:
+        """
+        Get the embedding dimensions by inferring from a test embedding.
+
+        This is useful when you need to know the vector dimensions without
+        hardcoding them, e.g., for initializing a vector store.
+
+        Returns:
+            Number of dimensions in the embedding vector
+
+        Examples:
+            >>> embedder = EmbeddingGenerator(model="all-mpnet-base-v2")
+            >>> dims = embedder.get_dimensions()
+            >>> print(dims)  # 768
+        """
+        test_embedding = self.embed_query("dimension test")
+        return len(test_embedding)
+
     def embed_query(self, query: str, task_instruction: str | None = None) -> List[float]:
         """
         Generate embedding for a single query.

--- a/src/piragi/stores/postgres.py
+++ b/src/piragi/stores/postgres.py
@@ -2,12 +2,10 @@
 
 import logging
 import time
-from typing import Any, Callable, Dict, List, Optional, TypeVar
-
+from typing import Any, Callable, Dict, List, Optional, TypeVar, TYPE_CHECKING
 import json
 
 from ..types import Chunk, Citation
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..embeddings import EmbeddingGenerator
@@ -50,10 +48,10 @@ class PostgresStore:
         >>>
         >>> # Auto-infer dimensions from embedder
         >>> from piragi import EmbeddingGenerator
-        >>> embedder = EmbeddingGenerator(model="all-mpnet-base-v2")
+        >>> embedder = EmbeddingGenerator(model="all-MiniLM-L6-v2")
         >>> store = PostgresStore(
         ...     connection_string="postgres://...",
-        ...     embedder=embedder  # Automatically detects 768 dimensions
+        ...     embedder=embedder  # Automatically detects 384 dimensions
         ... )
     """
 

--- a/src/piragi/stores/postgres.py
+++ b/src/piragi/stores/postgres.py
@@ -1,14 +1,28 @@
 """PostgreSQL vector store using pgvector."""
 
-from typing import Any, Dict, List, Optional
+import logging
+import time
+from typing import Any, Callable, Dict, List, Optional, TypeVar
+
 import json
 
 from ..types import Chunk, Citation
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..embeddings import EmbeddingGenerator
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
 
 
 class PostgresStore:
     """
     PostgreSQL vector store using pgvector extension.
+
+    Includes automatic connection resilience with configurable retry logic
+    for handling transient failures and connection issues.
 
     Requires:
         pip install psycopg2-binary pgvector
@@ -26,7 +40,34 @@ class PostgresStore:
         ...     user="user",
         ...     password="pass"
         ... )
+        >>>
+        >>> # With custom retry settings
+        >>> store = PostgresStore(
+        ...     connection_string="postgres://...",
+        ...     max_retries=5,
+        ...     retry_delay=1.0
+        ... )
+        >>>
+        >>> # Auto-infer dimensions from embedder
+        >>> from piragi import EmbeddingGenerator
+        >>> embedder = EmbeddingGenerator(model="all-mpnet-base-v2")
+        >>> store = PostgresStore(
+        ...     connection_string="postgres://...",
+        ...     embedder=embedder  # Automatically detects 768 dimensions
+        ... )
     """
+
+    # Error messages that indicate a retriable error
+    RETRIABLE_ERRORS = (
+        "transaction is aborted",
+        "server closed the connection",
+        "connection already closed",
+        "connection refused",
+        "could not connect to server",
+        "connection reset by peer",
+        "SSL connection has been closed unexpectedly",
+        "terminating connection due to administrator command",
+    )
 
     def __init__(
         self,
@@ -37,7 +78,10 @@ class PostgresStore:
         user: str = "postgres",
         password: str = "",
         table_name: str = "chunks",
-        vector_dimension: int = 768,
+        vector_dimension: Optional[int] = None,
+        max_retries: int = 3,
+        retry_delay: float = 0.5,
+        embedder: Optional["EmbeddingGenerator"] = None,
     ) -> None:
         """
         Initialize PostgreSQL store.
@@ -50,11 +94,20 @@ class PostgresStore:
             user: Database user
             password: Database password
             table_name: Table name for chunks
-            vector_dimension: Dimension of embedding vectors
+            vector_dimension: Dimension of embedding vectors. If not provided and
+                embedder is given, dimensions will be auto-inferred. If neither
+                is provided, defaults to 768.
+            max_retries: Maximum number of retry attempts for transient failures (default: 3)
+            retry_delay: Base delay between retries in seconds, doubles with each attempt (default: 0.5)
+            embedder: Optional EmbeddingGenerator instance for auto-inferring vector dimensions.
+                If provided and vector_dimension is not set, the embedder will be used to
+                determine the correct dimension automatically.
         """
         try:
             import psycopg2
             from pgvector.psycopg2 import register_vector
+            self._psycopg2 = psycopg2
+            self._register_vector = register_vector
         except ImportError:
             raise ImportError(
                 "PostgresStore requires psycopg2 and pgvector. "
@@ -62,26 +115,108 @@ class PostgresStore:
             )
 
         self.table_name = table_name
-        self.vector_dimension = vector_dimension
         self._chunk_texts: List[str] = []
 
-        # Connect
-        if connection_string:
-            self.conn = psycopg2.connect(connection_string)
+        # Determine vector dimension
+        if vector_dimension is not None:
+            self.vector_dimension = vector_dimension
+        elif embedder is not None:
+            # Auto-infer dimensions from embedder
+            logger.info("Auto-inferring vector dimensions from embedder...")
+            self.vector_dimension = embedder.get_dimensions()
+            logger.info(f"Detected vector dimension: {self.vector_dimension}")
         else:
-            self.conn = psycopg2.connect(
-                host=host,
-                port=port,
-                dbname=database,
-                user=user,
-                password=password,
-            )
+            # Default fallback
+            self.vector_dimension = 768
 
-        # Register pgvector
-        register_vector(self.conn)
+        # Retry configuration
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
+
+        # Store connection params for reconnection
+        self._connection_string = connection_string
+        self._connection_params = {
+            "host": host,
+            "port": port,
+            "dbname": database,
+            "user": user,
+            "password": password,
+        }
+
+        # Connect
+        self._connect()
 
         # Initialize schema
         self._init_schema()
+
+    def _connect(self) -> None:
+        """Establish database connection."""
+        if self._connection_string:
+            self.conn = self._psycopg2.connect(self._connection_string)
+        else:
+            self.conn = self._psycopg2.connect(**self._connection_params)
+
+        # Register pgvector
+        self._register_vector(self.conn)
+
+    def _reconnect(self) -> None:
+        """Close existing connection and establish a new one."""
+        try:
+            if hasattr(self, "conn") and self.conn:
+                self.conn.close()
+        except Exception:
+            pass  # Ignore errors when closing broken connection
+
+        self._connect()
+        logger.info("Successfully reconnected to PostgreSQL")
+
+    def _is_retriable_error(self, error: Exception) -> bool:
+        """Check if an error is retriable."""
+        error_msg = str(error).lower()
+        return any(msg in error_msg for msg in self.RETRIABLE_ERRORS)
+
+    def _execute_with_retry(self, operation: Callable[[], T]) -> T:
+        """
+        Execute an operation with automatic retry on transient failures.
+
+        Args:
+            operation: Callable that performs the database operation
+
+        Returns:
+            Result of the operation
+
+        Raises:
+            Last exception if all retries exhausted
+        """
+        last_exception = None
+
+        for attempt in range(self.max_retries + 1):
+            try:
+                return operation()
+            except Exception as e:
+                last_exception = e
+
+                if not self._is_retriable_error(e):
+                    # Non-retriable error, raise immediately
+                    raise
+
+                if attempt < self.max_retries:
+                    # Calculate delay with exponential backoff
+                    delay = self.retry_delay * (2 ** attempt)
+                    logger.warning(
+                        f"Database operation failed (attempt {attempt + 1}/{self.max_retries + 1}): {e}. "
+                        f"Retrying in {delay:.1f}s..."
+                    )
+                    time.sleep(delay)
+
+                    # Try to reconnect
+                    try:
+                        self._reconnect()
+                    except Exception as reconnect_error:
+                        logger.warning(f"Reconnection failed: {reconnect_error}")
+
+        # All retries exhausted
+        raise last_exception
 
     def _init_schema(self) -> None:
         """Create table and indexes if they don't exist."""
@@ -135,24 +270,27 @@ class PostgresStore:
             if chunk.embedding is None:
                 raise ValueError("All chunks must have embeddings")
 
-        with self.conn.cursor() as cur:
-            for chunk in chunks:
-                cur.execute(
-                    f"""
-                    INSERT INTO {self.table_name} (text, source, chunk_index, metadata, embedding)
-                    VALUES (%s, %s, %s, %s, %s)
-                    """,
-                    (
-                        chunk.text,
-                        chunk.source,
-                        chunk.chunk_index,
-                        json.dumps(chunk.metadata),
-                        chunk.embedding,
-                    ),
-                )
-                self._chunk_texts.append(chunk.text)
+        def _do_add():
+            with self.conn.cursor() as cur:
+                for chunk in chunks:
+                    cur.execute(
+                        f"""
+                        INSERT INTO {self.table_name} (text, source, chunk_index, metadata, embedding)
+                        VALUES (%s, %s, %s, %s, %s)
+                        """,
+                        (
+                            chunk.text,
+                            chunk.source,
+                            chunk.chunk_index,
+                            json.dumps(chunk.metadata),
+                            chunk.embedding,
+                        ),
+                    )
+                    self._chunk_texts.append(chunk.text)
 
-            self.conn.commit()
+                self.conn.commit()
+
+        self._execute_with_retry(_do_add)
 
     def search(
         self,
@@ -162,67 +300,79 @@ class PostgresStore:
         min_chunk_length: int = 100,
     ) -> List[Citation]:
         """Search for similar chunks using cosine similarity."""
-        with self.conn.cursor() as cur:
-            # Build query
-            where_clauses = [f"LENGTH(text) >= {min_chunk_length}"]
+        def _do_search() -> List[Citation]:
+            with self.conn.cursor() as cur:
+                # Build query
+                where_clauses = [f"LENGTH(text) >= {min_chunk_length}"]
 
-            if filters:
-                for key, value in filters.items():
-                    where_clauses.append(f"metadata->>'{key}' = '{value}'")
+                if filters:
+                    for key, value in filters.items():
+                        where_clauses.append(f"metadata->>'{key}' = '{value}'")
 
-            where_sql = " AND ".join(where_clauses)
+                where_sql = " AND ".join(where_clauses)
 
-            cur.execute(
-                f"""
-                SELECT text, source, metadata, 1 - (embedding <=> %s::vector) as score
-                FROM {self.table_name}
-                WHERE {where_sql}
-                ORDER BY embedding <=> %s::vector
-                LIMIT %s
-                """,
-                (query_embedding, query_embedding, top_k),
-            )
-
-            citations = []
-            for row in cur.fetchall():
-                citations.append(
-                    Citation(
-                        source=row[1],
-                        chunk=row[0],
-                        score=float(row[3]),
-                        metadata=row[2] if row[2] else {},
-                    )
+                cur.execute(
+                    f"""
+                    SELECT text, source, metadata, 1 - (embedding <=> %s::vector) as score
+                    FROM {self.table_name}
+                    WHERE {where_sql}
+                    ORDER BY embedding <=> %s::vector
+                    LIMIT %s
+                    """,
+                    (query_embedding, query_embedding, top_k),
                 )
 
-            return citations
+                citations = []
+                for row in cur.fetchall():
+                    citations.append(
+                        Citation(
+                            source=row[1],
+                            chunk=row[0],
+                            score=float(row[3]),
+                            metadata=row[2] if row[2] else {},
+                        )
+                    )
+
+                return citations
+
+        return self._execute_with_retry(_do_search)
 
     def delete_by_source(self, source: str) -> int:
         """Delete all chunks from a specific source."""
-        with self.conn.cursor() as cur:
-            cur.execute(
-                f"DELETE FROM {self.table_name} WHERE source = %s",
-                (source,),
-            )
-            deleted = cur.rowcount
-            self.conn.commit()
+        def _do_delete() -> int:
+            with self.conn.cursor() as cur:
+                cur.execute(
+                    f"DELETE FROM {self.table_name} WHERE source = %s",
+                    (source,),
+                )
+                deleted = cur.rowcount
+                self.conn.commit()
 
-        # Reload chunk texts
-        self._load_chunk_texts()
+            # Reload chunk texts
+            self._load_chunk_texts()
 
-        return deleted
+            return deleted
+
+        return self._execute_with_retry(_do_delete)
 
     def count(self) -> int:
         """Return the number of chunks in the store."""
-        with self.conn.cursor() as cur:
-            cur.execute(f"SELECT COUNT(*) FROM {self.table_name}")
-            return cur.fetchone()[0]
+        def _do_count() -> int:
+            with self.conn.cursor() as cur:
+                cur.execute(f"SELECT COUNT(*) FROM {self.table_name}")
+                return cur.fetchone()[0]
+
+        return self._execute_with_retry(_do_count)
 
     def clear(self) -> None:
         """Clear all data from the store."""
-        with self.conn.cursor() as cur:
-            cur.execute(f"TRUNCATE TABLE {self.table_name}")
-            self.conn.commit()
-        self._chunk_texts = []
+        def _do_clear():
+            with self.conn.cursor() as cur:
+                cur.execute(f"TRUNCATE TABLE {self.table_name}")
+                self.conn.commit()
+            self._chunk_texts = []
+
+        self._execute_with_retry(_do_clear)
 
     def get_all_chunk_texts(self) -> List[str]:
         """Get all chunk texts for hybrid search."""

--- a/tests/test_async_ragi.py
+++ b/tests/test_async_ragi.py
@@ -56,7 +56,49 @@ async def test_async_ragi_init(mock_ragi):
         config=None,
         store=None,
         graph=True,
+        embedder=None,
     )
+
+
+@pytest.mark.asyncio
+async def test_async_ragi_init_with_embedder(mock_ragi):
+    """Test AsyncRagi initialization with custom embedder."""
+    mock_class, mock_instance = mock_ragi
+
+    from piragi.async_ragi import AsyncRagi
+
+    mock_embedder = MagicMock()
+    mock_embedder.model_name = "custom-model"
+
+    kb = AsyncRagi("./docs", embedder=mock_embedder)
+
+    mock_class.assert_called_once_with(
+        sources="./docs",
+        persist_dir=".piragi",
+        config=None,
+        store=None,
+        graph=False,
+        embedder=mock_embedder,
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_ragi_shared_embedder(mock_ragi):
+    """Test that embedder can be shared across multiple AsyncRagi instances."""
+    mock_class, mock_instance = mock_ragi
+
+    from piragi.async_ragi import AsyncRagi
+
+    mock_embedder = MagicMock()
+
+    kb1 = AsyncRagi("./docs1", embedder=mock_embedder)
+    kb2 = AsyncRagi("./docs2", embedder=mock_embedder)
+
+    # Both should have passed the same embedder
+    calls = mock_class.call_args_list
+    assert len(calls) == 2
+    assert calls[0].kwargs.get("embedder") is mock_embedder
+    assert calls[1].kwargs.get("embedder") is mock_embedder
 
 
 @pytest.mark.asyncio

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -144,3 +144,121 @@ def test_sentence_break_with_initials():
 
     # Should not break after "J." or "K." in "J.K."
     assert "J.K. Rowling" in result or "C.S. Lewis" in result
+
+
+class TestMinChunkLength:
+    """Tests for min_chunk_length filtering."""
+
+    def test_min_chunk_length_default_zero(self):
+        """Test that default min_chunk_length is 0 (no filtering)."""
+        chunker = Chunker(chunk_size=512)
+        assert chunker.min_chunk_length == 0
+
+    def test_min_chunk_length_set(self):
+        """Test that min_chunk_length can be set."""
+        chunker = Chunker(chunk_size=512, min_chunk_length=200)
+        assert chunker.min_chunk_length == 200
+
+    def test_min_chunk_length_filters_short_chunks(self):
+        """Test that chunks shorter than min_chunk_length are filtered out."""
+        chunker = Chunker(chunk_size=100, min_chunk_length=50)
+
+        doc = Document(
+            content="""# Header
+
+Short.
+
+## Section 1
+
+This is a longer section with enough content to pass the minimum chunk length filter that we have set.
+
+## Section 2
+
+Tiny.
+
+## Section 3
+
+Another section with sufficient content that should definitely pass the minimum length requirement we configured.""",
+            source="test.md",
+            metadata={},
+        )
+
+        chunks = chunker.chunk_document(doc)
+
+        # All chunks should be at least min_chunk_length
+        for chunk in chunks:
+            assert len(chunk.text.strip()) >= 50, f"Chunk too short: {repr(chunk.text)}"
+
+    def test_min_chunk_length_reindexes_chunks(self):
+        """Test that chunk indices are re-indexed after filtering."""
+        chunker = Chunker(chunk_size=100, min_chunk_length=30)
+
+        doc = Document(
+            content="""# A
+
+Hi.
+
+## B
+
+This section has enough content to pass the filter easily.
+
+## C
+
+Ok.
+
+## D
+
+Another section with plenty of content to satisfy the minimum.""",
+            source="test.md",
+            metadata={},
+        )
+
+        chunks = chunker.chunk_document(doc)
+
+        # Indices should be sequential starting from 0
+        for i, chunk in enumerate(chunks):
+            assert chunk.chunk_index == i, f"Expected index {i}, got {chunk.chunk_index}"
+
+    def test_min_chunk_length_zero_no_filtering(self):
+        """Test that min_chunk_length=0 doesn't filter anything."""
+        chunker = Chunker(chunk_size=512, min_chunk_length=0)
+
+        doc = Document(
+            content="""# Header
+
+X
+
+## Section
+
+Y""",
+            source="test.md",
+            metadata={},
+        )
+
+        chunks = chunker.chunk_document(doc)
+
+        # Should have chunks for the short sections too
+        assert len(chunks) >= 2
+
+    def test_min_chunk_length_with_whitespace(self):
+        """Test that whitespace is stripped when checking length."""
+        chunker = Chunker(chunk_size=100, min_chunk_length=20)
+
+        doc = Document(
+            content="""# Header
+
+
+
+
+## Real Content
+
+This section has actual meaningful content that passes the filter.""",
+            source="test.md",
+            metadata={},
+        )
+
+        chunks = chunker.chunk_document(doc)
+
+        # Whitespace-only chunks should be filtered
+        for chunk in chunks:
+            assert len(chunk.text.strip()) >= 20

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -203,6 +203,91 @@ class TestRagiFilter:
         assert isinstance(answer, Answer)
 
 
+class TestRagiEmbedderInjection:
+    """Tests for custom embedder injection."""
+
+    def test_init_with_custom_embedder(self, temp_dir, mock_embeddings):
+        """Test initialization with custom embedder."""
+        mock_embedder = create_mock_embedding_generator(mock_embeddings)
+
+        persist_dir = os.path.join(temp_dir, "test_ragi")
+        kb = Ragi(persist_dir=persist_dir, embedder=mock_embedder)
+
+        # Verify custom embedder is used
+        assert kb.embedder is mock_embedder
+
+    def test_custom_embedder_used_for_add(
+        self, temp_dir, sample_text_file, mock_embeddings
+    ):
+        """Test that custom embedder is used when adding documents."""
+        mock_embedder = create_mock_embedding_generator(mock_embeddings)
+
+        persist_dir = os.path.join(temp_dir, "test_ragi")
+        kb = Ragi(persist_dir=persist_dir, embedder=mock_embedder)
+        kb.add(sample_text_file)
+
+        # Verify embedder's embed_chunks was called
+        mock_embedder.embed_chunks.assert_called()
+        assert kb.count() > 0
+
+    def test_shared_embedder_across_instances(self, temp_dir, mock_embeddings):
+        """Test that same embedder can be shared across multiple Ragi instances."""
+        mock_embedder = create_mock_embedding_generator(mock_embeddings)
+
+        persist_dir1 = os.path.join(temp_dir, "test_ragi1")
+        persist_dir2 = os.path.join(temp_dir, "test_ragi2")
+
+        kb1 = Ragi(persist_dir=persist_dir1, embedder=mock_embedder)
+        kb2 = Ragi(persist_dir=persist_dir2, embedder=mock_embedder)
+
+        # Both instances should share the same embedder
+        assert kb1.embedder is kb2.embedder
+        assert kb1.embedder is mock_embedder
+
+    def test_custom_embedder_overrides_config(self, temp_dir, mock_embeddings):
+        """Test that custom embedder takes precedence over config."""
+        mock_embedder = create_mock_embedding_generator(mock_embeddings)
+        mock_embedder.model_name = "custom-model"
+
+        persist_dir = os.path.join(temp_dir, "test_ragi")
+        kb = Ragi(
+            persist_dir=persist_dir,
+            embedder=mock_embedder,
+            config={"embedding": {"model": "different-model"}}
+        )
+
+        # Custom embedder should be used, not the one from config
+        assert kb.embedder is mock_embedder
+
+    @patch("piragi.retrieval.OpenAI")
+    def test_custom_embedder_used_for_query(
+        self,
+        mock_openai,
+        temp_dir,
+        sample_text_file,
+        mock_embeddings,
+        mock_llm_response,
+    ):
+        """Test that custom embedder is used for query embedding."""
+        mock_embedder = create_mock_embedding_generator(mock_embeddings)
+
+        # Mock LLM response
+        mock_client = MagicMock()
+        mock_completion = MagicMock()
+        mock_completion.choices = [MagicMock(message=MagicMock(content=mock_llm_response))]
+        mock_client.chat.completions.create.return_value = mock_completion
+        mock_openai.return_value = mock_client
+
+        persist_dir = os.path.join(temp_dir, "test_ragi")
+        kb = Ragi(persist_dir=persist_dir, embedder=mock_embedder)
+        kb.add(sample_text_file)
+
+        kb.ask("What is this?")
+
+        # Verify embed_query was called for the search
+        mock_embedder.embed_query.assert_called()
+
+
 class TestRagiUtility:
     """Tests for utility methods."""
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -26,7 +26,7 @@ def create_mock_embedding_generator(mock_embeddings):
     """Create a mock EmbeddingGenerator for testing."""
     mock_gen = MagicMock()
 
-    def embed_chunks_side_effect(chunks):
+    def embed_chunks_side_effect(chunks, on_progress=None):
         for chunk in chunks:
             chunk.embedding = mock_embeddings
         return chunks

--- a/tests/test_stores.py
+++ b/tests/test_stores.py
@@ -245,6 +245,134 @@ class TestPostgresStore:
             PostgresStore(connection_string="postgres://test")
 
 
+class TestPostgresStoreRetry:
+    """Tests for PostgresStore retry logic."""
+
+    def test_retriable_errors_constant(self):
+        """Test that RETRIABLE_ERRORS contains expected error patterns."""
+        from piragi.stores.postgres import PostgresStore
+
+        # Verify key error patterns are in the list
+        assert "transaction is aborted" in PostgresStore.RETRIABLE_ERRORS
+        assert "server closed the connection" in PostgresStore.RETRIABLE_ERRORS
+        assert "connection already closed" in PostgresStore.RETRIABLE_ERRORS
+        assert "connection refused" in PostgresStore.RETRIABLE_ERRORS
+
+    def test_is_retriable_error_method(self):
+        """Test _is_retriable_error method logic."""
+        from piragi.stores.postgres import PostgresStore
+
+        # Create instance without calling __init__
+        store = object.__new__(PostgresStore)
+        store.RETRIABLE_ERRORS = PostgresStore.RETRIABLE_ERRORS
+
+        # Test retriable errors
+        assert store._is_retriable_error(
+            Exception("current transaction is aborted, commands ignored")
+        ) is True
+        assert store._is_retriable_error(
+            Exception("server closed the connection unexpectedly")
+        ) is True
+        assert store._is_retriable_error(
+            Exception("connection already closed")
+        ) is True
+
+        # Test non-retriable errors
+        assert store._is_retriable_error(
+            Exception("syntax error at or near SELECT")
+        ) is False
+        assert store._is_retriable_error(
+            Exception("column 'foo' does not exist")
+        ) is False
+
+    def test_execute_with_retry_success_first_attempt(self):
+        """Test _execute_with_retry succeeds on first attempt."""
+        from piragi.stores.postgres import PostgresStore
+
+        store = object.__new__(PostgresStore)
+        store.RETRIABLE_ERRORS = PostgresStore.RETRIABLE_ERRORS
+        store.max_retries = 3
+        store.retry_delay = 0.01  # Fast for testing
+
+        call_count = 0
+
+        def successful_operation():
+            nonlocal call_count
+            call_count += 1
+            return "success"
+
+        result = store._execute_with_retry(successful_operation)
+        assert result == "success"
+        assert call_count == 1
+
+    def test_execute_with_retry_retries_on_retriable_error(self):
+        """Test _execute_with_retry retries on retriable errors."""
+        from piragi.stores.postgres import PostgresStore
+
+        store = object.__new__(PostgresStore)
+        store.RETRIABLE_ERRORS = PostgresStore.RETRIABLE_ERRORS
+        store.max_retries = 3
+        store.retry_delay = 0.01
+        store._reconnect = MagicMock()
+
+        call_count = 0
+
+        def fail_then_succeed():
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise Exception("transaction is aborted")
+            return "success"
+
+        result = store._execute_with_retry(fail_then_succeed)
+        assert result == "success"
+        assert call_count == 3
+        assert store._reconnect.call_count == 2  # Called on each retry
+
+    def test_execute_with_retry_raises_non_retriable_immediately(self):
+        """Test _execute_with_retry raises non-retriable errors immediately."""
+        from piragi.stores.postgres import PostgresStore
+
+        store = object.__new__(PostgresStore)
+        store.RETRIABLE_ERRORS = PostgresStore.RETRIABLE_ERRORS
+        store.max_retries = 3
+        store.retry_delay = 0.01
+
+        call_count = 0
+
+        def non_retriable_error():
+            nonlocal call_count
+            call_count += 1
+            raise Exception("syntax error")
+
+        with pytest.raises(Exception, match="syntax error"):
+            store._execute_with_retry(non_retriable_error)
+
+        assert call_count == 1  # No retries for non-retriable errors
+
+    def test_execute_with_retry_exhausts_retries(self):
+        """Test _execute_with_retry exhausts retries and raises."""
+        from piragi.stores.postgres import PostgresStore
+
+        store = object.__new__(PostgresStore)
+        store.RETRIABLE_ERRORS = PostgresStore.RETRIABLE_ERRORS
+        store.max_retries = 2
+        store.retry_delay = 0.01
+        store._reconnect = MagicMock()
+
+        call_count = 0
+
+        def always_fail():
+            nonlocal call_count
+            call_count += 1
+            raise Exception("transaction is aborted")
+
+        with pytest.raises(Exception, match="transaction is aborted"):
+            store._execute_with_retry(always_fail)
+
+        assert call_count == 3  # Initial + 2 retries
+
+
 class TestPineconeStore:
     """Tests for PineconeStore (mocked)."""
 

--- a/tests/test_stores.py
+++ b/tests/test_stores.py
@@ -373,6 +373,78 @@ class TestPostgresStoreRetry:
         assert call_count == 3  # Initial + 2 retries
 
 
+class TestDimensionInference:
+    """Tests for automatic dimension inference."""
+
+    def test_get_dimensions_method_exists(self):
+        """Test that EmbeddingGenerator has get_dimensions method."""
+        from piragi.embeddings import EmbeddingGenerator
+
+        # Verify the method exists
+        assert hasattr(EmbeddingGenerator, "get_dimensions")
+
+    def test_postgres_store_dimension_inference_logic(self):
+        """Test PostgresStore dimension inference logic without actual connection."""
+        from piragi.stores.postgres import PostgresStore
+
+        # Create a mock embedder with get_dimensions
+        mock_embedder = MagicMock()
+        mock_embedder.get_dimensions.return_value = 384
+
+        # Test the dimension inference logic directly
+        # We can't instantiate PostgresStore without psycopg2, but we can test the logic
+        store = object.__new__(PostgresStore)
+
+        # Simulate the dimension logic
+        vector_dimension = None
+        embedder = mock_embedder
+
+        if vector_dimension is not None:
+            result = vector_dimension
+        elif embedder is not None:
+            result = embedder.get_dimensions()
+        else:
+            result = 768
+
+        assert result == 384
+        mock_embedder.get_dimensions.assert_called_once()
+
+    def test_postgres_store_explicit_dimension_takes_precedence(self):
+        """Test that explicit vector_dimension takes precedence over embedder."""
+        mock_embedder = MagicMock()
+        mock_embedder.get_dimensions.return_value = 384
+
+        # Simulate the dimension logic with explicit dimension
+        vector_dimension = 1536
+        embedder = mock_embedder
+
+        if vector_dimension is not None:
+            result = vector_dimension
+        elif embedder is not None:
+            result = embedder.get_dimensions()
+        else:
+            result = 768
+
+        assert result == 1536
+        # get_dimensions should NOT be called when explicit dimension provided
+        mock_embedder.get_dimensions.assert_not_called()
+
+    def test_postgres_store_default_dimension(self):
+        """Test that default dimension is 768 when neither provided."""
+        # Simulate the dimension logic with no embedder
+        vector_dimension = None
+        embedder = None
+
+        if vector_dimension is not None:
+            result = vector_dimension
+        elif embedder is not None:
+            result = embedder.get_dimensions()
+        else:
+            result = 768
+
+        assert result == 768
+
+
 class TestPineconeStore:
     """Tests for PineconeStore (mocked)."""
 


### PR DESCRIPTION
## Description

This PR would add many improvements based on my discoveries while using this library on my project:  

1. **Embedder injection API** - Share embedders across Ragi instances to reduce memory                                                                                                    
2. **PostgreSQL connection resilience** - Automatic retry logic for eventual failures                                                                                                    
3. **min_chunk_length filter** - Filter out garbage/short chunks during chunking                                                                                                          
4. **Automatic dimension inference** - Auto-detect vector dimensions from embedder

## Changes

### Embedder Injection (`core.py`, `async_ragi.py`)                                                                                                                                       
- Added `embedder` parameter to `Ragi` and `AsyncRagi` constructors                                                                                                                         
- Allows sharing a single embedder across multiple instances (~400MB savings per instance)

### PostgreSQL Resilience (`stores/postgres.py`)                                                                                                                                          
- Added `max_retries` and `retry_delay` parameters with exponential backoff                                                                                                                 
- Auto-reconnect on connection failures                                                                                                                                                   
- Handle "transaction aborted" errors gracefully

### Chunk Filtering (`chunking.py`, `core.py`)                                                                                                                                            
- Added `min_chunk_length` parameter to `Chunker`                                                                                                                                           
- Filter chunks shorter than threshold (removes navigation, headers, boilerplate)                                                                                                         
- Re-index chunk indices after filtering

### Dimension Inference (`embeddings.py`, `stores/postgres.py`)                                                                                                                           
- Added `get_dimensions()` method to `EmbeddingGenerator`                                                                                                                                   
- Added `embedder` parameter to `PostgresStore` for auto-inference                                                                                                                          
- Eliminates manual dimension specification errors

Let me know what you think :)